### PR TITLE
[WIP] Compare Symbol memory addresses

### DIFF
--- a/src/symbol.cpp
+++ b/src/symbol.cpp
@@ -16,20 +16,15 @@ std::size_t Symbol::__hash__() const
 
 bool Symbol::__eq__(const Basic &o) const
 {
-    if (is_a<Symbol>(o)) {
-        if (this == &o) return true;
-        return name_ == static_cast<const Symbol &>(o).name_;
-    }
+    if (is_a<Symbol>(o)) return (this == &o);
     return false;
 }
 
 int Symbol::compare(const Basic &o) const
 {
     CSYMPY_ASSERT(is_a<Symbol>(o))
-    const Symbol &s = static_cast<const Symbol &>(o);
     if (this == &o) return 0;
-    if (name_ == s.name_) return 0;
-    return name_ < s.name_ ? -1 : 1;
+    return this < &o ? -1 : 1;
 }
 
 std::string Symbol::__str__() const

--- a/src/symbol.cpp
+++ b/src/symbol.cpp
@@ -16,8 +16,10 @@ std::size_t Symbol::__hash__() const
 
 bool Symbol::__eq__(const Basic &o) const
 {
-    if (is_a<Symbol>(o))
+    if (is_a<Symbol>(o)) {
+        if (this == &o) return true;
         return name_ == static_cast<const Symbol &>(o).name_;
+    }
     return false;
 }
 
@@ -25,6 +27,7 @@ int Symbol::compare(const Basic &o) const
 {
     CSYMPY_ASSERT(is_a<Symbol>(o))
     const Symbol &s = static_cast<const Symbol &>(o);
+    if (this == &o) return 0;
     if (name_ == s.name_) return 0;
     return name_ < s.name_ ? -1 : 1;
 }

--- a/src/tests/basic/test_basic.cpp
+++ b/src/tests/basic/test_basic.cpp
@@ -33,7 +33,7 @@ void test_symbol_hash()
     RCP<const Symbol> y  = rcp(new Symbol("y"));
 
     assert(x->__eq__(*x));
-    assert(x->__eq__(*x2));
+//    assert(x->__eq__(*x2));
     assert(!(x->__eq__(*y)));
     assert(x->__neq__(*y));
 
@@ -63,7 +63,7 @@ void test_symbol_dict()
     RCP<const Basic> x2 = rcp(new Symbol("x"));
     RCP<const Basic> y  = rcp(new Symbol("y"));
     assert( x !=  x2);  // The instances are different...
-    assert(eq(x, x2));  // ...but equal in the SymPy sense
+    //assert(eq(x, x2));  // ...but equal in the SymPy sense
 
     insert(d, x, rcp(new Integer(2)));
     insert(d, y, rcp(new Integer(3)));
@@ -292,6 +292,7 @@ void test_compare()
     RCP<const Basic> im2  = integer(-2);
     RCP<const Basic> i3  = integer(3);
     assert(x->compare(*x) == 0);
+    /*
     assert(x->compare(*y) == -1);
     assert(x->compare(*z) == -1);
     assert(y->compare(*x) == 1);
@@ -367,6 +368,7 @@ void test_compare()
     r2 = add(add(x, z), y);
     assert(r1->compare(*r2) == 0);
     assert(r2->compare(*r1) == 0);
+    */
 
     // These are compiler implementation specific, so we just make sure that if
     // x < y, then y > x.


### PR DESCRIPTION
Before:
```
$ ./expand2
Expanding: ((y + x + z + w)^15 + w)*(y + x + z + w)^15
1218ms
number of terms: 6272
```
After:
```
$ ./expand2
Expanding: ((y + x + z + w)^15 + w)*(y + x + z + w)^15
1204ms
number of terms: 6272
```
So it seems to provide about 1.15% speedup.

Note: This is a rebase of #91, and it also uses my own local branch now.