### PR TITLE
[WIP] Make RCP always non-null

### DIFF
--- a/benchmarks/expand1.cpp
+++ b/benchmarks/expand1.cpp
@@ -20,6 +20,7 @@ using CSymPy::Symbol;
 using CSymPy::umap_basic_int;
 using CSymPy::map_vec_int;
 using CSymPy::Integer;
+using CSymPy::zero;
 using CSymPy::multinomial_coefficients;
 using CSymPy::RCP;
 using CSymPy::rcp;
@@ -35,7 +36,7 @@ int main(int argc, char* argv[])
     RCP<Basic> w = rcp(new Symbol("w"));
     RCP<Basic> i60 = rcp(new Integer(60));
 
-    RCP<Basic> e, r;
+    RCP<Basic> e=zero, r=zero;
 
     e = pow(add(add(add(x, y), z), w), i60);
 

--- a/benchmarks/expand2.cpp
+++ b/benchmarks/expand2.cpp
@@ -19,6 +19,7 @@ using CSymPy::Symbol;
 using CSymPy::umap_basic_int;
 using CSymPy::map_vec_int;
 using CSymPy::Integer;
+using CSymPy::zero;
 using CSymPy::multinomial_coefficients;
 using CSymPy::RCP;
 using CSymPy::rcp;
@@ -34,7 +35,7 @@ int main(int argc, char* argv[])
     RCP<Basic> w = rcp(new Symbol("w"));
     RCP<Basic> i15 = rcp(new Integer(15));
 
-    RCP<Basic> e, f, r;
+    RCP<Basic> e=zero, f=zero, r=zero;
 
     e = pow(add(add(add(x, y), z), w), i15);
     f = mul(e, add(e, w));

--- a/benchmarks/expand3.cpp
+++ b/benchmarks/expand3.cpp
@@ -19,6 +19,7 @@ using CSymPy::Symbol;
 using CSymPy::umap_basic_int;
 using CSymPy::map_vec_int;
 using CSymPy::Integer;
+using CSymPy::zero;
 using CSymPy::multinomial_coefficients;
 using CSymPy::RCP;
 using CSymPy::rcp;
@@ -34,7 +35,7 @@ int main(int argc, char* argv[])
     RCP<Basic> w = rcp(new Symbol("w"));
     RCP<Basic> i100 = rcp(new Integer(100));
 
-    RCP<Basic> e, r;
+    RCP<Basic> e=zero, r=zero;
 
     e = pow(add(add(pow(x, y), pow(y, x)), pow(z, x)), i100);
 

--- a/src/add.cpp
+++ b/src/add.cpp
@@ -19,7 +19,6 @@ Add::Add(const RCP<Number> &coef, const umap_basic_int& dict)
 bool Add::is_canonical(const RCP<Number> &coef,
         const umap_basic_int& dict)
 {
-    if (coef == null) return false;
     if (dict.size() == 0) return false;
     if (dict.size() == 1) {
         // e.g. 0 + x, 0 + 2x
@@ -27,8 +26,6 @@ bool Add::is_canonical(const RCP<Number> &coef,
     }
     // Check that each term in 'dict' is in canonical form
     for (auto &p: dict) {
-        if (p.first == null) return false;
-        if (p.second == null) return false;
         // e.g. 2*3
         if (is_a_Number(*p.first) && is_a_Number(*p.second))
             return false;

--- a/src/add.cpp
+++ b/src/add.cpp
@@ -206,8 +206,8 @@ void as_coef_term(const RCP<Basic> &self, const Ptr<RCP<Number>> &coef,
 RCP<Basic> add(const RCP<Basic> &a, const RCP<Basic> &b)
 {
     CSymPy::umap_basic_int d;
-    RCP<Number> coef;
-    RCP<Basic> t;
+    RCP<Number> coef = zero;
+    RCP<Basic> t = zero;
     if (CSymPy::is_a<Add>(*a) && CSymPy::is_a<Add>(*b)) {
         coef = (rcp_static_cast<Add>(a))->coef_;
         d = (rcp_static_cast<Add>(a))->dict_;
@@ -220,7 +220,7 @@ RCP<Basic> add(const RCP<Basic> &a, const RCP<Basic> &b)
         if (is_a_Number(*b)) {
             iaddnum(outArg(coef), rcp_static_cast<Number>(b));
         } else {
-            RCP<Number> coef2;
+            RCP<Number> coef2 = zero;
             as_coef_term(b, outArg(coef2), outArg(t));
             Add::dict_add_term(d, coef2, t);
         }
@@ -230,7 +230,7 @@ RCP<Basic> add(const RCP<Basic> &a, const RCP<Basic> &b)
         if (is_a_Number(*a)) {
             iaddnum(outArg(coef), rcp_static_cast<Number>(a));
         } else {
-            RCP<Number> coef2;
+            RCP<Number> coef2 = zero;
             as_coef_term(a, outArg(coef2), outArg(t));
             Add::dict_add_term(d, coef2, t);
         }
@@ -260,8 +260,8 @@ RCP<Basic> add_expand(const RCP<Add> &self)
 {
     umap_basic_int d;
     RCP<Number> coef_overall = self->coef_;
-    RCP<Number> coef;
-    RCP<Basic> tmp, tmp2;
+    RCP<Number> coef = zero;
+    RCP<Basic> tmp = zero, tmp2 = zero;
     for (auto &p: self->dict_) {
         tmp = expand(p.first);
         if (is_a<Add>(*tmp)) {

--- a/src/csympy_rcp.h
+++ b/src/csympy_rcp.h
@@ -172,7 +172,6 @@ using Teuchos::rcp;
 using Teuchos::rcp_dynamic_cast;
 using Teuchos::rcp_static_cast;
 using Teuchos::typeName;
-using Teuchos::null;
 using Teuchos::print_stack_on_segfault;
 
 #endif

--- a/src/csympy_rcp.h
+++ b/src/csympy_rcp.h
@@ -27,9 +27,6 @@ enum ENull { null };
 template<class T>
 class RCP {
 public:
-    // TODO: remove this default constructor to ensure that RCP is never null.
-    // Also go over this class and remove all checks for ptr_ == 0 or NULL
-    RCP(ENull null_arg = null) : ptr_(NULL) {}
     explicit RCP(T *p) : ptr_(p) {
         CSYMPY_ASSERT(p != NULL)
         (ptr_->refcount_)++;

--- a/src/mul.cpp
+++ b/src/mul.cpp
@@ -227,8 +227,8 @@ RCP<Basic> mul(const RCP<Basic> &a, const RCP<Basic> &b)
         for (auto &p: B->dict_)
             Mul::dict_add_term(d, p.second, p.first);
     } else if (CSymPy::is_a<Mul>(*a)) {
-        RCP<Basic> exp;
-        RCP<Basic> t;
+        RCP<Basic> exp = zero;
+        RCP<Basic> t = zero;
         coef = (rcp_static_cast<Mul>(a))->coef_;
         d = (rcp_static_cast<Mul>(a))->dict_;
         if (is_a_Number(*b)) {
@@ -238,8 +238,8 @@ RCP<Basic> mul(const RCP<Basic> &a, const RCP<Basic> &b)
             Mul::dict_add_term(d, exp, t);
         }
     } else if (CSymPy::is_a<Mul>(*b)) {
-        RCP<Basic> exp;
-        RCP<Basic> t;
+        RCP<Basic> exp = zero;
+        RCP<Basic> t = zero;
         coef = (rcp_static_cast<Mul>(b))->coef_;
         d = (rcp_static_cast<Mul>(b))->dict_;
         if (is_a_Number(*a)) {
@@ -249,8 +249,8 @@ RCP<Basic> mul(const RCP<Basic> &a, const RCP<Basic> &b)
             Mul::dict_add_term(d, exp, t);
         }
     } else {
-        RCP<Basic> exp;
-        RCP<Basic> t;
+        RCP<Basic> exp = zero;
+        RCP<Basic> t = zero;
         Mul::as_base_exp(a, outArg(exp), outArg(t));
         insert(d, t, exp);
         Mul::as_base_exp(b, outArg(exp), outArg(t));
@@ -312,8 +312,8 @@ RCP<Basic> mul_expand_two(const RCP<Basic> &a, const RCP<Basic> &b)
     } else if (is_a<Add>(*b)) {
         umap_basic_int d;
         RCP<Number> coef_overall=rcp_static_cast<Add>(b)->coef_;
-        RCP<Number> coef;
-        RCP<Basic> tmp;
+        RCP<Number> coef = zero;
+        RCP<Basic> tmp = zero;
 
         if (!coef_overall->is_zero()) {
             tmp = mul(a, coef_overall);
@@ -367,7 +367,7 @@ RCP<Basic> mul_expand_two(const RCP<Basic> &a, const RCP<Basic> &b)
 
 RCP<Basic> mul_expand(const RCP<Mul> &self)
 {
-    RCP<Basic> a, b;
+    RCP<Basic> a = zero, b = zero;
     self->as_two_terms(outArg(a), outArg(b));
     a = expand(a);
     b = expand(b);
@@ -378,7 +378,7 @@ RCP<Basic> Mul::power_all_terms(const RCP<Basic> &exp)
 {
     CSymPy::map_basic_basic d;
     RCP<Basic> new_coef = pow(coef_, exp);
-    RCP<Basic> new_exp;
+    RCP<Basic> new_exp = zero;
     for (auto &p: dict_) {
         new_exp = mul(p.second, exp);
         if (is_a<Integer>(*new_exp) &&
@@ -412,7 +412,7 @@ RCP<Basic> Mul::diff(const RCP<Symbol> &x) const
                 Mul::dict_add_term(d, q.second, q.first);
             }
         } else {
-            RCP<Basic> exp, t;
+            RCP<Basic> exp = zero, t = zero;
             Mul::as_base_exp(factor, outArg(exp), outArg(t));
             Mul::dict_add_term(d, exp, t);
         }

--- a/src/mul.cpp
+++ b/src/mul.cpp
@@ -19,7 +19,6 @@ Mul::Mul(const RCP<Number> &coef, const map_basic_basic& dict)
 bool Mul::is_canonical(const RCP<Number> &coef,
         const map_basic_basic& dict)
 {
-    if (coef == null) return false;
     // e.g. 0*x*y
     if (coef->is_zero())
         return false;
@@ -30,8 +29,6 @@ bool Mul::is_canonical(const RCP<Number> &coef,
     }
     // Check that each term in 'dict' is in canonical form
     for (auto &p: dict) {
-        if (p.first == null) return false;
-        if (p.second == null) return false;
         // e.g. 2^3, (2/3)^4
         if (is_a_Number(*p.first) && is_a<Integer>(*p.second))
             return false;

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -229,7 +229,7 @@ RCP<Basic> pow_expand(const RCP<Pow> &self)
                             // Instead of:
                             insert(d, base, exp);
                         } else {
-                            RCP<Basic> exp2, t, tmp;
+                            RCP<Basic> exp2=zero, t=zero, tmp=zero;
                             tmp = pow(base, exp);
                             Mul::as_base_exp(tmp, outArg(exp2), outArg(t));
                             Mul::dict_add_term(d, exp2, t);

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -17,8 +17,6 @@ Pow::Pow(const RCP<Basic> &base, const RCP<Basic> &exp)
 
 bool Pow::is_canonical(const RCP<Basic> &base, const RCP<Basic> &exp)
 {
-    if (base == null) return false;
-    if (exp == null) return false;
     // e.g. 0^x
     if (is_a<Integer>(*base) && rcp_static_cast<Integer>(base)->is_zero())
         return false;

--- a/src/tests/basic/test_arit.cpp
+++ b/src/tests/basic/test_arit.cpp
@@ -79,7 +79,7 @@ void test_mul()
     RCP<Basic> i4 = rcp(new Integer(4));
     RCP<Basic> i6 = rcp(new Integer(6));
 
-    RCP<Basic> r1, r2;
+    RCP<Basic> r1=zero, r2=zero;
 
     r1 = mul(pow(x, y), z);
     r2 = mul(z, pow(x, y));
@@ -129,7 +129,7 @@ void test_sub()
     RCP<Basic> i3 = rcp(new Integer(3));
     RCP<Basic> i4 = rcp(new Integer(4));
 
-    RCP<Basic> r1, r2;
+    RCP<Basic> r1=zero, r2=zero;
 
     r1 = sub(i3, i2);
     r2 = one;
@@ -185,7 +185,7 @@ void test_div()
     assert(!(integer(-1)->is_positive()));
     assert(integer(-1)->is_negative());
 
-    RCP<Basic> r1, r2;
+    RCP<Basic> r1=zero, r2=zero;
 
     r1 = pow(i3, i2);
     r2 = integer(9);
@@ -240,8 +240,8 @@ void test_pow()
     RCP<Basic> i9 = rcp(new Integer(9));
     RCP<Basic> i27 = rcp(new Integer(27));
 
-    RCP<Basic> r1;
-    RCP<Basic> r2;
+    RCP<Basic> r1 = zero;
+    RCP<Basic> r2 = zero;
 
     r1 = mul(x, x);
     r2 = pow(x, i2);
@@ -324,8 +324,8 @@ void test_expand1()
     RCP<Basic> i3 = rcp(new Integer(3));
     RCP<Basic> i4 = rcp(new Integer(10));
 
-    RCP<Basic> r1;
-    RCP<Basic> r2;
+    RCP<Basic> r1 = zero;
+    RCP<Basic> r2 = zero;
 
     r1 = pow(add(add(add(x, y), z), w), i4);
 
@@ -360,8 +360,8 @@ void test_expand2()
     RCP<Basic> i25 = rcp(new Integer(25));
     RCP<Basic> i30 = rcp(new Integer(30));
 
-    RCP<Basic> r1;
-    RCP<Basic> r2;
+    RCP<Basic> r1 = zero;
+    RCP<Basic> r2 = zero;
 
     r1 = mul(w, add(add(x, y), z)); // w*(x+y+z)
     std::cout << *r1 << std::endl;
@@ -436,7 +436,7 @@ void test_expand3()
     RCP<Basic> w = rcp(new Symbol("w"));
     RCP<Basic> i4 = rcp(new Integer(2));
 
-    RCP<Basic> e, f, r;
+    RCP<Basic> e=zero, f=zero, r=zero;
 
     e = pow(add(add(add(x, y), z), w), i4);
     f = mul(e, add(e, w));

--- a/src/tests/basic/test_basic.cpp
+++ b/src/tests/basic/test_basic.cpp
@@ -140,7 +140,7 @@ void test_integer()
 
 void test_rational()
 {
-    RCP<Number> r1, r2, r3;
+    RCP<Number> r1=zero, r2=zero, r3=zero;
     r1 = Rational::from_two_ints(integer(5), integer(6));
     std::cout << *r1 << std::endl;
     assert(eq(r1, Rational::from_two_ints(integer(5), integer(6))));
@@ -254,7 +254,7 @@ void test_mul()
 
 void test_diff()
 {
-    RCP<Basic> r1, r2;
+    RCP<Basic> r1=zero, r2=zero;
     RCP<Symbol> x  = symbol("x");
     RCP<Symbol> y  = symbol("y");
     RCP<Basic> i2  = integer(2);
@@ -278,7 +278,7 @@ void test_diff()
 
 void test_compare()
 {
-    RCP<Basic> r1, r2;
+    RCP<Basic> r1=zero, r2=zero;
     RCP<Symbol> x  = symbol("x");
     RCP<Symbol> y  = symbol("y");
     RCP<Symbol> z  = symbol("z");

--- a/src/tests/basic/test_functions.cpp
+++ b/src/tests/basic/test_functions.cpp
@@ -39,8 +39,8 @@ void test_sin()
     RCP<Basic> im1 = integer(-1);
     RCP<Basic> i2 = integer(2);
 
-    RCP<Basic> r1;
-    RCP<Basic> r2;
+    RCP<Basic> r1 = zero;
+    RCP<Basic> r2 = zero;
 
     r1 = sin(x);
     r2 = sin(x);
@@ -96,8 +96,8 @@ void test_cos()
     RCP<Basic> im1 = integer(-1);
     RCP<Basic> i2 = integer(2);
 
-    RCP<Basic> r1;
-    RCP<Basic> r2;
+    RCP<Basic> r1 = zero;
+    RCP<Basic> r2 = zero;
 
     r1 = cos(x);
     r2 = cos(x);
@@ -125,8 +125,8 @@ void test_f()
     RCP<Basic> im1 = integer(-1);
     RCP<Basic> i2 = integer(2);
 
-    RCP<Basic> r1;
-    RCP<Basic> r2;
+    RCP<Basic> r1 = zero;
+    RCP<Basic> r2 = zero;
 
     r1 = function_symbol("f", x);
     r2 = function_symbol("f", x);

--- a/src/tests/basic/test_poly.cpp
+++ b/src/tests/basic/test_poly.cpp
@@ -19,6 +19,7 @@ using CSymPy::Symbol;
 using CSymPy::umap_basic_int;
 using CSymPy::map_vec_int;
 using CSymPy::Integer;
+using CSymPy::zero;
 using CSymPy::multinomial_coefficients;
 using CSymPy::map_vec_mpz;
 using CSymPy::expr2poly;
@@ -57,7 +58,7 @@ void test_expand()
     RCP<Basic> w = rcp(new Symbol("w"));
     RCP<Basic> i4 = rcp(new Integer(2));
 
-    RCP<Basic> e, f1, f2, r;
+    RCP<Basic> e=zero, f1=zero, f2=zero, r=zero;
 
     e = pow(add(add(add(x, y), z), w), i4);
     f1 = expand(e);


### PR DESCRIPTION
This is just to see how fast things get. The Cython interface can't currently work with non-null RCP pointers.

When running benchmarks, I don't see any significant difference in speed.

This is the same as #74 but using my local branch.