### PR TITLE
Use placement new in the C wrapper

### DIFF
--- a/src/cwrapper.cpp
+++ b/src/cwrapper.cpp
@@ -31,11 +31,8 @@ extern "C" {
 
 void basic_init(basic s)
 {
-    if (sizeof(RCP<const Basic>) > SIZE_OF_RCP_BASIC) {
-        // The preallocated array is smaller than what is needed for
-        // RCP<const Basic>
-        throw std::runtime_error("Incorrect value in SIZE_OF_RCP_BASIC");
-    }
+    // This check only happens at compile time
+    static_assert(sizeof(RCP<const Basic>) == SIZE_OF_RCP_BASIC, "Size SIZE_OF_RCP_BASIC is not correct");
     // No allocation is being done, but the constructor of RCP is called and
     // the instance is initialized at the memory address 's'.
     new(s) RCP<const Basic>();

--- a/src/cwrapper.cpp
+++ b/src/cwrapper.cpp
@@ -23,8 +23,8 @@ using CSymPy::Number;
 using CSymPy::rcp_static_cast;
 using CSymPy::is_a;
 
-#define RCP_cast(x) (static_cast<RCP<const Basic> *>(static_cast<void *>(x)));
-#define RCP_cast_const(x) (static_cast<const RCP<const Basic> *>(static_cast<const void *>(x)));
+#define RCP_cast(x) (static_cast<RCP<const Basic> *>(static_cast<void *>(x)))
+#define RCP_const_cast(x) (static_cast<const RCP<const Basic> *>(static_cast<const void *>(x)))
 
 extern "C" {
 
@@ -42,153 +42,116 @@ void basic_new(basic s)
 
 void basic_free(basic s)
 {
-    RCP<const Basic> *p = RCP_cast(s);
-    p->~RCP();
+    RCP_cast(s)->~RCP();
 }
 
 void symbol_set(basic s, char* c)
 {
-    RCP<const Basic> *p = RCP_cast(s);
-    *p = CSymPy::symbol(std::string(c));
+    *RCP_cast(s) = CSymPy::symbol(std::string(c));
 }
 
 void integer_set_si(basic s, long i)
 {
-    RCP<const Basic> *p = RCP_cast(s);
-    *p = CSymPy::integer(mpz_class(i));
+    *RCP_cast(s) = CSymPy::integer(mpz_class(i));
 }
 
 void integer_set_ui(basic s, unsigned long i)
 {
-    RCP<const Basic> *p = RCP_cast(s);
-    *p = CSymPy::integer(mpz_class(i));
+    *RCP_cast(s) = CSymPy::integer(mpz_class(i));
 }
 
 void integer_set_mpz(basic s, const mpz_t i)
 {
-    RCP<const Basic> *p = RCP_cast(s);
-    *p = CSymPy::integer(mpz_class(i));
+    *RCP_cast(s) = CSymPy::integer(mpz_class(i));
 }
 
 void integer_set_str(basic s, char* c)
 {
-    RCP<const Basic> *p = RCP_cast(s);
-    *p = CSymPy::integer(mpz_class(c, 10));
+    *RCP_cast(s) = CSymPy::integer(mpz_class(c, 10));
 }
 
 void rational_set_si(basic s, long a, long b)
 {
-    RCP<const Basic> *p = RCP_cast(s);
-    *p = CSymPy::Rational::from_mpq(mpq_class(a, b));
+    *RCP_cast(s) = CSymPy::Rational::from_mpq(mpq_class(a, b));
 }
 
 void rational_set_ui(basic s, unsigned long a, unsigned long b)
 {
-    RCP<const Basic> *p = RCP_cast(s);
-    *p = CSymPy::Rational::from_mpq(mpq_class(a, b));
+    *RCP_cast(s) = CSymPy::Rational::from_mpq(mpq_class(a, b));
 }
 
 int rational_set(basic s, const basic a, const basic b)
 {
-    RCP<const Basic> *p = RCP_cast(s);
-    const RCP<const Basic> *a2 = RCP_cast_const(a);
-    const RCP<const Basic> *b2 = RCP_cast_const(b);
     if (!is_a_Integer(a) || !is_a_Integer(b)) {
         return 0;
     }
-    *p = CSymPy::Rational::from_two_ints(rcp_static_cast<const Integer>(*a2),
-                rcp_static_cast<const Integer>(*b2));
+    *RCP_cast(s) = CSymPy::Rational::from_two_ints(
+            rcp_static_cast<const Integer>(*RCP_const_cast(a)),
+            rcp_static_cast<const Integer>(*RCP_const_cast(b)));
     return 1;
 }
 
 void rational_set_mpq(basic s, const mpq_t i)
 {
-    RCP<const Basic> *p = RCP_cast(s);
-    *p = CSymPy::Rational::from_mpq(mpq_class(i));
+    *RCP_cast(s) = CSymPy::Rational::from_mpq(mpq_class(i));
 }
 
 int basic_diff(basic s, const basic expr, basic const symbol)
 {
     if (!is_a_Symbol(symbol))
         return 0;
-    RCP<const Basic> *s2 = RCP_cast(s);
-    const RCP<const Basic> *expr2 = RCP_cast_const(expr);
-    const RCP<const Basic> *symbol2 = RCP_cast_const(symbol);
-    *s2 = (*expr2)->diff(rcp_static_cast<const Symbol>(*symbol2));
+    *RCP_cast(s) = (*RCP_const_cast(expr))->diff(rcp_static_cast<const Symbol>
+            (*RCP_const_cast(symbol)));
     return 1;
 }
 
 void basic_assign(basic a, const basic b) {
-    RCP<const Basic> *a2 = RCP_cast(a);
-    const RCP<const Basic> *b2 = RCP_cast_const(b);
-    *a2 = RCP<const Basic>(*b2);
+    *RCP_cast(a) = RCP<const Basic>(*RCP_const_cast(b));
 }
 
 void basic_add(basic s, const basic a, const basic b)
 {
-    RCP<const Basic> *s2 = RCP_cast(s);
-    const RCP<const Basic> *a2 = RCP_cast_const(a);
-    const RCP<const Basic> *b2 = RCP_cast_const(b);
-    *s2 = CSymPy::add(*a2, *b2);
+    *RCP_cast(s) = CSymPy::add(*RCP_const_cast(a), *RCP_const_cast(b));
 }
 
 void basic_sub(basic s, const basic a, const basic b)
 {
-    RCP<const Basic> *s2 = RCP_cast(s);
-    const RCP<const Basic> *a2 = RCP_cast_const(a);
-    const RCP<const Basic> *b2 = RCP_cast_const(b);
-    *s2 = CSymPy::sub(*a2, *b2);
+    *RCP_cast(s) = CSymPy::sub(*RCP_const_cast(a), *RCP_const_cast(b));
 }
 
 void basic_mul(basic s, const basic a, const basic b)
 {
-    RCP<const Basic> *s2 = RCP_cast(s);
-    const RCP<const Basic> *a2 = RCP_cast_const(a);
-    const RCP<const Basic> *b2 = RCP_cast_const(b);
-    *s2 = CSymPy::mul(*a2, *b2);
+    *RCP_cast(s) = CSymPy::mul(*RCP_const_cast(a), *RCP_const_cast(b));
 }
 
 void basic_pow(basic s, const basic a, const basic b)
 {
-    RCP<const Basic> *s2 = RCP_cast(s);
-    const RCP<const Basic> *a2 = RCP_cast_const(a);
-    const RCP<const Basic> *b2 = RCP_cast_const(b);
-    *s2 = CSymPy::pow(*a2, *b2);
+    *RCP_cast(s) = CSymPy::pow(*RCP_const_cast(a), *RCP_const_cast(b));
 }
 
 void basic_div(basic s, const basic a, const basic b)
 {
-    RCP<const Basic> *s2 = RCP_cast(s);
-    const RCP<const Basic> *a2 = RCP_cast_const(a);
-    const RCP<const Basic> *b2 = RCP_cast_const(b);
-    *s2 = CSymPy::div(*a2, *b2);
+    *RCP_cast(s) = CSymPy::div(*RCP_const_cast(a), *RCP_const_cast(b));
 }
 
 void basic_neg(basic s, const basic a)
 {
-    RCP<const Basic> *s2 = RCP_cast(s);
-    const RCP<const Basic> *a2 = RCP_cast_const(a);
-    *s2 = CSymPy::neg(*a2);
+    *RCP_cast(s) = CSymPy::neg(*RCP_const_cast(a));
 }
 
 void basic_abs(basic s, const basic a)
 {
-    RCP<const Basic> *s2 = RCP_cast(s);
-    const RCP<const Basic> *a2 = RCP_cast_const(a);
-    *s2 = CSymPy::abs(*a2);
+    *RCP_cast(s) = CSymPy::abs(*RCP_const_cast(a));
 }
 
 void basic_expand(basic s, const basic a)
 {
-    RCP<const Basic> *s2 = RCP_cast(s);
-    const RCP<const Basic> *a2 = RCP_cast_const(a);
-    *s2 = CSymPy::expand(*a2);
+    *RCP_cast(s) = CSymPy::expand(*RCP_const_cast(a));
 }
 
 char* basic_str(const basic s)
 {
-    const RCP<const Basic> *s2 = RCP_cast_const(s);
-    std::string str = (*s2)->__str__();
+    std::string str = (*RCP_const_cast(s))->__str__();
     char *cc = new char[str.length()+1];
     std::strcpy(cc, str.c_str());
     return cc;
@@ -201,18 +164,15 @@ void basic_str_free(char* s)
 
 int is_a_Integer(const basic c)
 {
-    const RCP<const Basic> *c2 = RCP_cast_const(c);
-    return is_a<Integer>(*(*c2));
+    return is_a<Integer>(*(*RCP_const_cast(c)));
 }
 int is_a_Rational(const basic c)
 {
-    const RCP<const Basic> *c2 = RCP_cast_const(c);
-    return is_a<Rational>(*(*c2));
+    return is_a<Rational>(*(*RCP_const_cast(c)));
 }
 int is_a_Symbol(const basic c)
 {
-    const RCP<const Basic> *c2 = RCP_cast_const(c);
-    return is_a<Symbol>(*(*c2));
+    return is_a<Symbol>(*(*RCP_const_cast(c)));
 }
 
 }

--- a/src/cwrapper.cpp
+++ b/src/cwrapper.cpp
@@ -31,9 +31,13 @@ extern "C" {
 
 void basic_init(basic s)
 {
+#if defined(WITH_CSYMPY_RCP)
     // These checks only happen at compile time
     static_assert(sizeof(RCP<const Basic>) == SIZE_OF_RCP_BASIC, "Size SIZE_OF_RCP_BASIC is not correct");
     static_assert(std::alignment_of<RCP<const Basic>>::value == alignof(s), "'basic' alignment is not correct");
+#else
+    throw std::runtime_error("Teuchos::RCP is not compatible with the C wrappers");
+#endif
     // No allocation is being done, but the constructor of RCP is called and
     // the instance is initialized at the memory address 's'.
     new(s) RCP<const Basic>();

--- a/src/cwrapper.cpp
+++ b/src/cwrapper.cpp
@@ -23,8 +23,9 @@ using CSymPy::Number;
 using CSymPy::rcp_static_cast;
 using CSymPy::is_a;
 
-#define RCP_cast(x) (static_cast<RCP<const Basic> *>(static_cast<void *>(x)))
-#define RCP_const_cast(x) (static_cast<const RCP<const Basic> *>(static_cast<const void *>(x)))
+#define RCP_cast_general(x, CONST) (static_cast<CONST RCP<const Basic> *>(static_cast<CONST void *>(x)))
+#define RCP_cast(x) RCP_cast_general(x, )
+#define RCP_const_cast(x) RCP_cast_general(x, const)
 
 extern "C" {
 

--- a/src/cwrapper.cpp
+++ b/src/cwrapper.cpp
@@ -29,7 +29,7 @@ using CSymPy::is_a;
 
 extern "C" {
 
-void basic_new(basic s)
+void basic_init(basic s)
 {
     if (sizeof(RCP<const Basic>) > SIZE_OF_RCP_BASIC) {
         // The preallocated array is smaller than what is needed for

--- a/src/cwrapper.cpp
+++ b/src/cwrapper.cpp
@@ -34,7 +34,7 @@ void basic_init(basic s)
 #if defined(WITH_CSYMPY_RCP)
     // These checks only happen at compile time
     static_assert(sizeof(RCP<const Basic>) == SIZE_OF_RCP_BASIC, "Size SIZE_OF_RCP_BASIC is not correct");
-    static_assert(std::alignment_of<RCP<const Basic>>::value == alignof(s), "'basic' alignment is not correct");
+    static_assert(std::alignment_of<RCP<const Basic>>::value == std::alignment_of<basic>::value, "'basic' alignment is not correct");
 #else
     throw std::runtime_error("Teuchos::RCP is not compatible with the C wrappers");
 #endif

--- a/src/cwrapper.cpp
+++ b/src/cwrapper.cpp
@@ -34,9 +34,9 @@ void basic_init(basic s)
 #if defined(WITH_CSYMPY_RCP)
     // These checks only happen at compile time.
     // Check that 'basic' has the correct size:
-    static_assert(sizeof(RCP<const Basic>) == sizeof(basic), "Size SIZE_OF_RCP_BASIC is not correct");
+    static_assert(sizeof(RCP<const Basic>) == sizeof(basic), "Size of 'basic' is not correct");
     // Check that 'basic' has the correct alignment:
-    static_assert(std::alignment_of<RCP<const Basic>>::value == std::alignment_of<basic>::value, "'basic' alignment is not correct");
+    static_assert(std::alignment_of<RCP<const Basic>>::value == std::alignment_of<basic>::value, "Alignment of 'basic' is not correct");
 #else
     throw std::runtime_error("Teuchos::RCP is not compatible with the C wrappers");
 #endif

--- a/src/cwrapper.cpp
+++ b/src/cwrapper.cpp
@@ -23,7 +23,7 @@ using CSymPy::Number;
 using CSymPy::rcp_static_cast;
 using CSymPy::is_a;
 
-#define RCP_cast_general(x, CONST) (static_cast<CONST RCP<const Basic> *>(static_cast<CONST void *>(x)))
+#define RCP_cast_general(x, CONST) (reinterpret_cast<CONST RCP<const Basic> *>(x))
 #define RCP_cast(x) RCP_cast_general(x, )
 #define RCP_const_cast(x) RCP_cast_general(x, const)
 

--- a/src/cwrapper.cpp
+++ b/src/cwrapper.cpp
@@ -32,14 +32,18 @@ extern "C" {
 void basic_init(basic s)
 {
 #if defined(WITH_CSYMPY_RCP)
-    // These checks only happen at compile time
-    static_assert(sizeof(RCP<const Basic>) == SIZE_OF_RCP_BASIC, "Size SIZE_OF_RCP_BASIC is not correct");
+    // These checks only happen at compile time.
+    // Check that 'basic' has the correct size:
+    static_assert(sizeof(RCP<const Basic>) == sizeof(basic), "Size SIZE_OF_RCP_BASIC is not correct");
+    // Check that 'basic' has the correct alignment:
     static_assert(std::alignment_of<RCP<const Basic>>::value == std::alignment_of<basic>::value, "'basic' alignment is not correct");
 #else
     throw std::runtime_error("Teuchos::RCP is not compatible with the C wrappers");
 #endif
     // No allocation is being done, but the constructor of RCP is called and
-    // the instance is initialized at the memory address 's'.
+    // the instance is initialized at the memory address 's'. The above checks
+    // make sure that 's' has the correct size and alignment, which is
+    // necessary for placement new, otherwise the results are undefined.
     new(s) RCP<const Basic>();
 }
 

--- a/src/cwrapper.cpp
+++ b/src/cwrapper.cpp
@@ -31,8 +31,9 @@ extern "C" {
 
 void basic_init(basic s)
 {
-    // This check only happens at compile time
+    // These checks only happen at compile time
     static_assert(sizeof(RCP<const Basic>) == SIZE_OF_RCP_BASIC, "Size SIZE_OF_RCP_BASIC is not correct");
+    static_assert(std::alignment_of<RCP<const Basic>>::value == alignof(s), "'basic' alignment is not correct");
     // No allocation is being done, but the constructor of RCP is called and
     // the instance is initialized at the memory address 's'.
     new(s) RCP<const Basic>();

--- a/src/cwrapper.cpp
+++ b/src/cwrapper.cpp
@@ -23,127 +23,172 @@ using CSymPy::Number;
 using CSymPy::rcp_static_cast;
 using CSymPy::is_a;
 
-struct CWrapper {
-    RCP<const Basic> ptr;
-};
+#define RCP_cast(x) (static_cast<RCP<const Basic> *>(static_cast<void *>(x)));
+#define RCP_cast_const(x) (static_cast<const RCP<const Basic> *>(static_cast<const void *>(x)));
 
 extern "C" {
 
-void basic_free(basic s)
+void basic_new(basic s)
 {
-    delete s;
+    if (sizeof(RCP<const Basic>) > SIZE_OF_RCP_BASIC) {
+        // The preallocated array is smaller than what is needed for
+        // RCP<const Basic>
+        throw std::runtime_error("Incorrect value in SIZE_OF_RCP_BASIC");
+    }
+    // No allocation is being done, but the constructor of RCP is called and
+    // the instance is initialized at the memory address 's'.
+    new(s) RCP<const Basic>();
 }
 
-basic basic_new()
+void basic_free(basic s)
 {
-    return new CWrapper();
+    RCP<const Basic> *p = RCP_cast(s);
+    p->~RCP();
 }
 
 void symbol_set(basic s, char* c)
 {
-    s->ptr = CSymPy::symbol(std::string(c));
+    RCP<const Basic> *p = RCP_cast(s);
+    *p = CSymPy::symbol(std::string(c));
 }
 
 void integer_set_si(basic s, long i)
 {
-    s->ptr = CSymPy::integer(mpz_class(i));
+    RCP<const Basic> *p = RCP_cast(s);
+    *p = CSymPy::integer(mpz_class(i));
 }
 
 void integer_set_ui(basic s, unsigned long i)
 {
-    s->ptr = CSymPy::integer(mpz_class(i));
+    RCP<const Basic> *p = RCP_cast(s);
+    *p = CSymPy::integer(mpz_class(i));
 }
 
 void integer_set_mpz(basic s, const mpz_t i)
 {
-    s->ptr = CSymPy::integer(mpz_class(i));
+    RCP<const Basic> *p = RCP_cast(s);
+    *p = CSymPy::integer(mpz_class(i));
 }
 
 void integer_set_str(basic s, char* c)
 {
-    s->ptr = CSymPy::integer(mpz_class(c, 10));
+    RCP<const Basic> *p = RCP_cast(s);
+    *p = CSymPy::integer(mpz_class(c, 10));
 }
 
 void rational_set_si(basic s, long a, long b)
 {
-    s->ptr = CSymPy::Rational::from_mpq(mpq_class(a, b));
+    RCP<const Basic> *p = RCP_cast(s);
+    *p = CSymPy::Rational::from_mpq(mpq_class(a, b));
 }
 
 void rational_set_ui(basic s, unsigned long a, unsigned long b)
 {
-    s->ptr = CSymPy::Rational::from_mpq(mpq_class(a, b));
+    RCP<const Basic> *p = RCP_cast(s);
+    *p = CSymPy::Rational::from_mpq(mpq_class(a, b));
 }
 
 int rational_set(basic s, const basic a, const basic b)
 {
+    RCP<const Basic> *p = RCP_cast(s);
+    const RCP<const Basic> *a2 = RCP_cast_const(a);
+    const RCP<const Basic> *b2 = RCP_cast_const(b);
     if (!is_a_Integer(a) || !is_a_Integer(b)) {
         return 0;
     }
-    s->ptr = CSymPy::Rational::from_two_ints(rcp_static_cast<const Integer>(a->ptr),
-                rcp_static_cast<const Integer>(b->ptr));
+    *p = CSymPy::Rational::from_two_ints(rcp_static_cast<const Integer>(*a2),
+                rcp_static_cast<const Integer>(*b2));
     return 1;
 }
 
 void rational_set_mpq(basic s, const mpq_t i)
 {
-    s->ptr = CSymPy::Rational::from_mpq(mpq_class(i));
+    RCP<const Basic> *p = RCP_cast(s);
+    *p = CSymPy::Rational::from_mpq(mpq_class(i));
 }
 
 int basic_diff(basic s, const basic expr, basic const symbol)
 {
     if (!is_a_Symbol(symbol))
         return 0;
-    s->ptr = expr->ptr->diff(rcp_static_cast<const Symbol>(symbol->ptr));
+    RCP<const Basic> *s2 = RCP_cast(s);
+    const RCP<const Basic> *expr2 = RCP_cast_const(expr);
+    const RCP<const Basic> *symbol2 = RCP_cast_const(symbol);
+    *s2 = (*expr2)->diff(rcp_static_cast<const Symbol>(*symbol2));
     return 1;
 }
 
 void basic_assign(basic a, const basic b) {
-    a->ptr = RCP<const Basic>(b->ptr);
+    RCP<const Basic> *a2 = RCP_cast(a);
+    const RCP<const Basic> *b2 = RCP_cast_const(b);
+    *a2 = RCP<const Basic>(*b2);
 }
 
 void basic_add(basic s, const basic a, const basic b)
 {
-    s->ptr = CSymPy::add(a->ptr, b->ptr);
+    RCP<const Basic> *s2 = RCP_cast(s);
+    const RCP<const Basic> *a2 = RCP_cast_const(a);
+    const RCP<const Basic> *b2 = RCP_cast_const(b);
+    *s2 = CSymPy::add(*a2, *b2);
 }
 
 void basic_sub(basic s, const basic a, const basic b)
 {
-    s->ptr = CSymPy::sub(a->ptr, b->ptr);
+    RCP<const Basic> *s2 = RCP_cast(s);
+    const RCP<const Basic> *a2 = RCP_cast_const(a);
+    const RCP<const Basic> *b2 = RCP_cast_const(b);
+    *s2 = CSymPy::sub(*a2, *b2);
 }
 
 void basic_mul(basic s, const basic a, const basic b)
 {
-    s->ptr = CSymPy::mul(a->ptr, b->ptr);
+    RCP<const Basic> *s2 = RCP_cast(s);
+    const RCP<const Basic> *a2 = RCP_cast_const(a);
+    const RCP<const Basic> *b2 = RCP_cast_const(b);
+    *s2 = CSymPy::mul(*a2, *b2);
 }
 
 void basic_pow(basic s, const basic a, const basic b)
 {
-    s->ptr = CSymPy::pow(a->ptr, b->ptr);
+    RCP<const Basic> *s2 = RCP_cast(s);
+    const RCP<const Basic> *a2 = RCP_cast_const(a);
+    const RCP<const Basic> *b2 = RCP_cast_const(b);
+    *s2 = CSymPy::pow(*a2, *b2);
 }
 
 void basic_div(basic s, const basic a, const basic b)
 {
-    s->ptr = CSymPy::div(a->ptr, b->ptr);
+    RCP<const Basic> *s2 = RCP_cast(s);
+    const RCP<const Basic> *a2 = RCP_cast_const(a);
+    const RCP<const Basic> *b2 = RCP_cast_const(b);
+    *s2 = CSymPy::div(*a2, *b2);
 }
 
 void basic_neg(basic s, const basic a)
 {
-    s->ptr = CSymPy::neg(a->ptr);
+    RCP<const Basic> *s2 = RCP_cast(s);
+    const RCP<const Basic> *a2 = RCP_cast_const(a);
+    *s2 = CSymPy::neg(*a2);
 }
 
 void basic_abs(basic s, const basic a)
 {
-    s->ptr = CSymPy::abs(a->ptr);
+    RCP<const Basic> *s2 = RCP_cast(s);
+    const RCP<const Basic> *a2 = RCP_cast_const(a);
+    *s2 = CSymPy::abs(*a2);
 }
 
 void basic_expand(basic s, const basic a)
 {
-    s->ptr = CSymPy::expand(a->ptr);
+    RCP<const Basic> *s2 = RCP_cast(s);
+    const RCP<const Basic> *a2 = RCP_cast_const(a);
+    *s2 = CSymPy::expand(*a2);
 }
 
 char* basic_str(const basic s)
 {
-    std::string str = s->ptr->__str__();
+    const RCP<const Basic> *s2 = RCP_cast_const(s);
+    std::string str = (*s2)->__str__();
     char *cc = new char[str.length()+1];
     std::strcpy(cc, str.c_str());
     return cc;
@@ -156,15 +201,18 @@ void basic_str_free(char* s)
 
 int is_a_Integer(const basic c)
 {
-    return is_a<Integer>(*(c->ptr));
+    const RCP<const Basic> *c2 = RCP_cast_const(c);
+    return is_a<Integer>(*(*c2));
 }
 int is_a_Rational(const basic c)
 {
-    return is_a<Rational>(*(c->ptr));
+    const RCP<const Basic> *c2 = RCP_cast_const(c);
+    return is_a<Rational>(*(*c2));
 }
 int is_a_Symbol(const basic c)
 {
-    return is_a<Symbol>(*(c->ptr));
+    const RCP<const Basic> *c2 = RCP_cast_const(c);
+    return is_a<Symbol>(*(*c2));
 }
 
 }

--- a/src/cwrapper.h
+++ b/src/cwrapper.h
@@ -7,18 +7,21 @@
 extern "C" {
 #endif
 
-// SIZE_OF_RCP_BASIC must be set to be equal to sizeof(RCP<const Basic>). We
-// cannot use C++ in this file, so we need to calculate the size differently.
-// The size of the RCP object on most platforms should then be just the size of
-// the 'T *ptr_' pointer that it contains (as there is no virtual function
-// table). Pointers are all the same size, so we just use the size of 'void *'
-// here. However, this is checked at compile time in cwrapper.cpp, so if the
-// size is different on some platform, the compilation will fail.
-#define SIZE_OF_RCP_BASIC sizeof(void *)
-
+// The size of 'basic_struct' must be the same as RCP<const Basic> *and* they
+// must have the same alignment (because we allocate RCP<const Basic> into the
+// memory occupied by this struct in cwrapper.cpp). We cannot use C++ in this
+// file, so we need to use C tools to arrive at the correct size and alignment.
+// The size of the RCP object on most platforms should be just the size of the
+// 'T *ptr_' pointer that it contains (as there is no virtual function table)
+// and the alignment should also be of a pointer. So we just put 'void *data'
+// as the only member of the struct, that should have the correct size and
+// alignment.  However, this is checked at compile time in cwrapper.cpp, so if
+// the size or alignment is different on some platform, the compilation will
+// fail --- in that case one needs to modify the contents of this struct to
+// adjust its size and/or alignment.
 typedef struct
 {
-    char data[SIZE_OF_RCP_BASIC]  __attribute__ ((aligned (8)));
+    void *data;
 } basic_struct;
 
 typedef basic_struct basic[1];

--- a/src/cwrapper.h
+++ b/src/cwrapper.h
@@ -11,11 +11,14 @@ extern "C" {
 
 typedef char basic[SIZE_OF_RCP_BASIC];
 
-//! basic is a pointer to a CWrapper which wraps the C++ class.
-// A basic type should be initialized using the return value of basic_init(), before any
-// function is called. Assignment should be done only by using basic_assign()
+//! basic is internally implemented as a char array of sufficient size to hold
+// the RCP<const Basic> instance, that is then used by the user to allocate the
+// memory needed for RCP<const Basic> on the stack. A basic type should be
+// initialized using basic_init(), before any function is called.  Assignment
+// should be done only by using basic_assign(). Before the variable goes out of
+// scope, basic_free() must be called.
 
-//! Return a new basic instance.
+//! Initialize a new basic instance.
 void basic_init(basic s);
 //! Assign value of b to a.
 void basic_assign(basic a, const basic b);

--- a/src/cwrapper.h
+++ b/src/cwrapper.h
@@ -18,7 +18,7 @@ extern "C" {
 
 typedef struct
 {
-    char ptr[SIZE_OF_RCP_BASIC]  __attribute__ ((aligned (8)));
+    char data[SIZE_OF_RCP_BASIC]  __attribute__ ((aligned (8)));
 } basic_struct;
 
 typedef basic_struct basic[1];

--- a/src/cwrapper.h
+++ b/src/cwrapper.h
@@ -7,7 +7,14 @@
 extern "C" {
 #endif
 
-#define SIZE_OF_RCP_BASIC 8
+// SIZE_OF_RCP_BASIC must be set to be equal to sizeof(RCP<const Basic>). We
+// cannot use C++ in this file, so we need to calculate the size differently.
+// The size of the RCP object on most platforms should then be just the size of
+// the 'T *ptr_' pointer that it contains (as there is no virtual function
+// table). Pointers are all the same size, so we just use the size of 'void *'
+// here. However, this is checked at compile time in cwrapper.cpp, so if the
+// size is different on some platform, the compilation will fail.
+#define SIZE_OF_RCP_BASIC sizeof(void *)
 
 typedef char basic[SIZE_OF_RCP_BASIC];
 

--- a/src/cwrapper.h
+++ b/src/cwrapper.h
@@ -16,7 +16,12 @@ extern "C" {
 // size is different on some platform, the compilation will fail.
 #define SIZE_OF_RCP_BASIC sizeof(void *)
 
-typedef char basic[SIZE_OF_RCP_BASIC];
+typedef struct
+{
+    char ptr[SIZE_OF_RCP_BASIC]  __attribute__ ((aligned (8)));
+} basic_struct;
+
+typedef basic_struct basic[1];
 
 //! basic is internally implemented as a char array of sufficient size to hold
 // the RCP<const Basic> instance, that is then used by the user to allocate the

--- a/src/cwrapper.h
+++ b/src/cwrapper.h
@@ -12,11 +12,11 @@ extern "C" {
 typedef char basic[SIZE_OF_RCP_BASIC];
 
 //! basic is a pointer to a CWrapper which wraps the C++ class.
-// A basic type should be initialized using the return value of basic_new(), before any
+// A basic type should be initialized using the return value of basic_init(), before any
 // function is called. Assignment should be done only by using basic_assign()
 
 //! Return a new basic instance.
-void basic_new(basic s);
+void basic_init(basic s);
 //! Assign value of b to a.
 void basic_assign(basic a, const basic b);
 //! Free the C++ class wrapped by s.

--- a/src/cwrapper.h
+++ b/src/cwrapper.h
@@ -7,15 +7,16 @@
 extern "C" {
 #endif
 
-typedef struct CWrapper CWrapper;
+#define SIZE_OF_RCP_BASIC 8
+
+typedef char basic[SIZE_OF_RCP_BASIC];
 
 //! basic is a pointer to a CWrapper which wraps the C++ class.
 // A basic type should be initialized using the return value of basic_new(), before any
 // function is called. Assignment should be done only by using basic_assign()
-typedef CWrapper* basic;
 
 //! Return a new basic instance.
-basic basic_new();
+void basic_new(basic s);
 //! Assign value of b to a.
 void basic_assign(basic a, const basic b);
 //! Free the C++ class wrapped by s.

--- a/src/tests/cwrapper/test_cwrapper.c
+++ b/src/tests/cwrapper/test_cwrapper.c
@@ -4,9 +4,9 @@
 void test_cwrapper() {
     char* s;
     basic x, y, z;
-    basic_new(x);
-    basic_new(y);
-    basic_new(z);
+    basic_init(x);
+    basic_init(y);
+    basic_init(z);
     symbol_set(x, "x");
     symbol_set(y, "y");
     symbol_set(z, "z");
@@ -15,7 +15,7 @@ void test_cwrapper() {
     printf("Symbol : %s\n", s);
     basic_str_free(s);
     basic e;
-    basic_new(e);
+    basic_init(e);
 
     integer_set_ui(e, 123);
     s = basic_str(e);

--- a/src/tests/cwrapper/test_cwrapper.c
+++ b/src/tests/cwrapper/test_cwrapper.c
@@ -3,7 +3,10 @@
 
 void test_cwrapper() {
     char* s;
-    basic x = basic_new(), y = basic_new(), z = basic_new();
+    basic x, y, z;
+    basic_new(x);
+    basic_new(y);
+    basic_new(z);
     symbol_set(x, "x");
     symbol_set(y, "y");
     symbol_set(z, "z");
@@ -11,7 +14,8 @@ void test_cwrapper() {
     s = basic_str(x);
     printf("Symbol : %s\n", s);
     basic_str_free(s);
-    basic e = basic_new();
+    basic e;
+    basic_new(e);
 
     integer_set_ui(e, 123);
     s = basic_str(e);


### PR DESCRIPTION
This doesn't use any heap allocation, and it looks to me that a program in C should be as fast as an equivalent program in C++ now.

There are still things that need to be polished, for example I would like to get rid of declaring the `RCP<const Basic> *s2 = RCP_cast(s);` and just use `RCP_cast(s)` directly, but the compiler complains.

The `SIZE_OF_RCP_BASIC` thing is also not ideal, but we can't use `sizeof(RCP<const Basic>)` in the C header file, so I don't know how to do it any other way.

/cc @isuruf, @fredrik-johansson