### PR TITLE
Fix to the missing parentheses issue #380

### DIFF
--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -92,8 +92,12 @@ std::string Pow::__str__() const
     std::ostringstream o;
     if (is_a<Add>(*base_) || is_a<Mul>(*base_) || is_a<Pow>(*base_)) {
         o << "(" << *base_ << ")";
-    } else if ((is_a<Rational>(*base_) || is_a<Integer>(*base_)) &&
-                rcp_static_cast<const Number>(base_)->is_negative()) {
+    } else if (is_a<Integer>(*base_) &&
+                rcp_static_cast<const Integer>(base_)->is_negative()) {
+        o << "(" << *base_ << ")";
+    } else if (is_a<Rational>(*base_) &&
+                (!(rcp_static_cast<const Rational>(base_)->is_int()) ||
+                rcp_static_cast<const Rational>(base_)->is_negative())) {
         o << "(" << *base_ << ")";
     } else if (is_a<Complex>(*base_) &&
                 (rcp_static_cast<const Complex>(base_)->imaginary_)!=0) {

--- a/src/tests/printing/test_printing.cpp
+++ b/src/tests/printing/test_printing.cpp
@@ -47,6 +47,16 @@ void test_printing()
     r = mul(integer(2), pow(symbol("x"), integer(2)));
     assert(r->__str__() == "2*x^2");
 
+    r = mul(integer(23), mul(pow(div(integer(5), integer(2)), div(integer(1), integer(2))),
+        pow(div(integer(7), integer(3)), div(integer(1), integer(2)))));
+    assert(r->__str__() == "23*(7/3)^(1/2)*(5/2)^(1/2)");
+	
+    r = pow(div(symbol("x"), integer(2)), div(integer(1), integer(2)));
+    assert(r->__str__() == "((1/2)*x)^(1/2)");
+
+    r = pow(div(integer(3), integer(2)),div(integer(1), integer(2)));
+    assert(r->__str__() == "(3/2)^(1/2)");	
+	
     r1 = mul(integer(12), pow(integer(196), div(integer(-1), integer(2))));
     r2 = mul(integer(294), pow(integer(196), div(integer(-1), integer(2))));
     r = add(integer(-51), mul(r1, r2));


### PR DESCRIPTION
printing: fix to the missing parentheses issue #380
Example:
```
In[1]: (Integer(3)/2)**(Integer(1)/2)
```
Before fix-`Out[1]: 3/2^(1/2)`
After fix-`Out[1]:(3/2)^(1/2)`

Added 3 more tests in test_printing.cpp to test the fix.
```
In[1]: (Integer(23))*((Integer(5)/2)**(Integer(1)/2))*((Integer(7)/3)**(Integer(1)/2))
Out[1]: 23*(7/3)^(1/2)*(5/2)^(1/2)

In[2]: ((symbols('x')/2)**(Integer(1)/2))
Out[2]: ((1/2)*x)^(1/2)

In [3]: (Integer(3)/2)**(Integer(1)/3)
Out[3]: (3/2)^(1/3) 
```