### PR TITLE
Fix ((sqrt(2)+sqrt(2)*x)**2).expand()

### DIFF
--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -398,7 +398,8 @@ RCP<const Basic> pow_expand(const RCP<const Pow> &self)
                     tmp = pow(base, exp);
                     if (is_a<Mul>(*tmp)) {
                         for (auto &p: (rcp_static_cast<const Mul>(tmp))->dict_) {
-                            Mul::dict_add_term(d, p.second, p.first);
+                            Mul::dict_add_term_new(outArg(overall_coeff), d,
+                                    p.second, p.first);
                         }
                         imulnum(outArg(overall_coeff), (rcp_static_cast<const Mul>(tmp))->coef_);
                     } else {

--- a/src/tests/basic/test_arit.cpp
+++ b/src/tests/basic/test_arit.cpp
@@ -776,6 +776,10 @@ void test_expand2()
     r1 = pow(mul(sqrt(i3), mul(y, add(one, pow(i3, div(one, i3))))), i3);
     r1 = expand(mul(r1, add(r1, one)));
     std::cout << r1->__str__() << std::endl;
+
+    r1 = expand(pow(add(sqrt(i2), mul(sqrt(i2), x)), i2));
+    r2 = add(i2, add(mul(i4, x), mul(i2, pow(x, i2))));
+    assert(eq(r1, r2));
 }
 
 void test_expand3()


### PR DESCRIPTION
The problem was that sqrt(2)*sqrt(2) = 2 was left in the Mul's dictionary, so
we needed to use dict_add_term_new(), which moves the coefficient 2 from the
dictionary into the overall coefficient.

A test was added. Fixes #397.