### PR TITLE
Check for type before casting in Mul::dict_add_term_new

### DIFF
--- a/src/complex.cpp
+++ b/src/complex.cpp
@@ -101,4 +101,44 @@ RCP<const Number> Complex::from_two_nums(const Number &re,
     }
 }
 
+RCP<const Number> pow_number(const RCP<const Number> &x, long n)
+{
+    RCP<const Number> r, p;
+    long mask = 1;
+    mpq_class re = 1;
+    mpq_class im = 0;
+    r = one;
+    p = x;
+    while (mask > 0 && n >= mask) {
+        if (n & mask)
+            r = mulnum(r, p);
+        mask = mask << 1;
+        p = mulnum(p, p);
+    }
+    return r;
+}
+
+RCP<const Number> Complex::powcomp(const Integer &other) const {
+    if (this->is_re_zero()) {
+        // Imaginary Number raised to an integer power.
+        RCP<const Number> im = Rational::from_mpq(this->imaginary_);
+        RCP<const Number> res;
+        res = mod(other, *integer(4));
+        if (eq(res, zero)) {
+            res = one;
+        } else if (eq(res, one)) {
+            res = I;
+        } else if (eq(res, integer(2))) {
+            res = minus_one;
+        } else {
+            res = mulnum(I, minus_one);
+        }
+        return mulnum(im->pow(other), res);
+    } else if (other.is_positive()) {
+        return pow_number(rcp(this), other.as_int());
+    } else {
+        return pow_number(divnum(one, rcp(this)), -1 * other.as_int());
+    }
+};
+
 } // CSymPy

--- a/src/complex.h
+++ b/src/complex.h
@@ -192,6 +192,11 @@ public:
             return from_mpq((this->real_ * other.i) / conjugate, (this->imaginary_ * (-other.i)) / conjugate);
         }
     }
+    /*! Pow Complex
+     * \param other of type Integer
+     * */
+    RCP<const Number> powcomp(const Integer &other) const;
+
     //! Converts the param `other` appropriately and then calls `addcomp`
     virtual RCP<const Number> add(const Number &other) const {
         if (is_a<Rational>(other)) {
@@ -263,8 +268,7 @@ public:
     //! Converts the param `other` appropriately and then calls `powcomp`
     virtual RCP<const Number> pow(const Number &other) const {
         if (is_a<Integer>(other)) {
-            // Needs to be implemented
-            throw std::runtime_error("Not implemented.");
+            return powcomp(static_cast<const Integer&>(other));
         } else {
             throw std::runtime_error("Not implemented.");
         }

--- a/src/mul.cpp
+++ b/src/mul.cpp
@@ -225,18 +225,20 @@ void Mul::dict_add_term_new(const Ptr<RCP<const Number>> &coef, map_basic_basic 
                 }
             }
         } else if (is_a<Rational>(*it->second)) {
-            mpz_class q, r, num, den;
-            num = rcp_static_cast<const Rational>(it->second)->i.get_num();
-            den = rcp_static_cast<const Rational>(it->second)->i.get_den();
-            // Here we make the exponent postive and a fraction between
-            // 0 and 1.
-            if (num > den || num < 0) {
-                mpz_fdiv_qr(q.get_mpz_t(), r.get_mpz_t(), num.get_mpz_t(),
-                    den.get_mpz_t());
+            if (is_a<Integer>(*t) || is_a<Rational>(*t)) {
+                mpz_class q, r, num, den;
+                num = rcp_static_cast<const Rational>(it->second)->i.get_num();
+                den = rcp_static_cast<const Rational>(it->second)->i.get_den();
+                // Here we make the exponent postive and a fraction between
+                // 0 and 1.
+                if (num > den || num < 0) {
+                    mpz_fdiv_qr(q.get_mpz_t(), r.get_mpz_t(), num.get_mpz_t(),
+                                den.get_mpz_t());
 
-                it->second = Rational::from_mpq(mpq_class(r, den));
-                imulnum(outArg(*coef), pownum(rcp_static_cast<const Number>(t),
-                    rcp_static_cast<const Number>(integer(q))));
+                    it->second = Rational::from_mpq(mpq_class(r, den));
+                    imulnum(outArg(*coef), pownum(rcp_static_cast<const Number>(t),
+                                                  rcp_static_cast<const Number>(integer(q))));
+                }
             }
         }
     }

--- a/src/mul.cpp
+++ b/src/mul.cpp
@@ -225,7 +225,7 @@ void Mul::dict_add_term_new(const Ptr<RCP<const Number>> &coef, map_basic_basic 
                 }
             }
         } else if (is_a<Rational>(*it->second)) {
-            if (is_a<Integer>(*t) || is_a<Rational>(*t)) {
+            if (is_a_Number(*t)) {
                 mpz_class q, r, num, den;
                 num = rcp_static_cast<const Rational>(it->second)->i.get_num();
                 den = rcp_static_cast<const Rational>(it->second)->i.get_den();

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -86,48 +86,6 @@ int Pow::compare(const Basic &o) const
         return base_cmp;
 }
 
-RCP<const Number> pow_number(const RCP<const Number> &x, long n)
-{
-    RCP<const Number> r, p;
-    long mask = 1;
-    r = one;
-    p = x;
-    while (mask > 0 && n >= mask) {
-        if (n & mask)
-            r = mulnum(r, p);
-        mask = mask << 1;
-        p = mulnum(p, p);
-    }
-    return r;
-}
-
-void pow_complex(const Ptr<RCP<const Number>> &self,
-    const RCP<const Complex> &base_,
-    const Integer &exp_)
-{
-    if (base_->is_re_zero()) {
-        // Imaginary Number raised to an integer power.
-        RCP<const Number> im = Rational::from_mpq(base_->imaginary_);
-        RCP<const Number> res;
-        res = mod(exp_, *integer(4));
-        if (eq(res, zero)) {
-            res = one;
-        } else if (eq(res, one)) {
-            res = I;
-        } else if (eq(res, integer(2))) {
-            res = minus_one;
-        } else {
-            res = mulnum(I, minus_one);
-        }
-        *self = mulnum(im->pow(exp_), res);
-    } else if (exp_.is_positive()) {
-        *self = pow_number(base_, exp_.as_int());
-    } else {
-        *self = pow_number(divnum(one, base_), -1 * exp_.as_int());
-    }
-
-}
-
 RCP<const Basic> pow(const RCP<const Basic> &a, const RCP<const Basic> &b)
 {
     if (eq(b, zero)) return one;
@@ -155,8 +113,7 @@ RCP<const Basic> pow(const RCP<const Basic> &a, const RCP<const Basic> &b)
             } else if (is_a<Complex>(*a)) {
                 RCP<const Complex> exp_new = rcp_static_cast<const Complex>(a);
                 RCP<const Integer> pow_new = rcp_static_cast<const Integer>(b);
-                RCP<const Number> res;
-                pow_complex(outArg(res), exp_new, *pow_new);
+                RCP<const Number> res = exp_new->pow(*pow_new);
                 return res;
             } else {
                 throw std::runtime_error("Not implemented");
@@ -380,8 +337,7 @@ RCP<const Basic> pow_expand(const RCP<const Pow> &self)
                         pownum(i2->second,
                             rcp_static_cast<const Number>(exp)));
                     } else if (is_a<Complex>(*(i2->second))) {
-                        RCP<const Number> tmp;
-                        pow_complex(outArg(tmp), rcp_static_cast<const Complex>(i2->second), *exp);
+                        RCP<const Number> tmp = rcp_static_cast<const Complex>(i2->second)->pow(*exp);
                         imulnum(outArg(overall_coeff), tmp);
                     }
                 }

--- a/src/tests/basic/test_arit.cpp
+++ b/src/tests/basic/test_arit.cpp
@@ -176,6 +176,15 @@ void test_mul()
     r1 = mul(r1, r2);
     r2 = mul(pow(x, i2), c2);
     assert(eq(r1, r2));
+
+    r1 = mul(sqrt(x), x);
+    r2 = pow(x, div(i3, i2));
+    assert(eq(r1, r2));
+
+    r1 = mul(pow(i2, x), pow(i2, sub(div(i3, i2), x)));
+    r2 = mul(i2, pow(i2, div(one, i2)));
+    std::cout << r1->__str__() << " " << r2->__str__() <<std::endl;
+    assert(eq(r1, r2));
 }
 
 void test_sub()

--- a/src/tests/basic/test_arit.cpp
+++ b/src/tests/basic/test_arit.cpp
@@ -183,7 +183,13 @@ void test_mul()
 
     r1 = mul(pow(i2, x), pow(i2, sub(div(i3, i2), x)));
     r2 = mul(i2, pow(i2, div(one, i2)));
-    std::cout << r1->__str__() << " " << r2->__str__() <<std::endl;
+    std::cout << r1->__str__() << std::endl;
+    assert(eq(r1, r2));
+
+    rc1 = Complex::from_two_nums(*one, *one);
+    r1 = pow(rc1, x);
+    r1 = mul(r1, pow(rc1, sub(div(i3, i2), x)));
+    r2 = mul(rc1, pow(rc1, div(one, i2)));
     assert(eq(r1, r2));
 }
 


### PR DESCRIPTION
Earlier the test
```C++
r1 = mul(sqrt(x), x);
```
would result in a segfault because the type is not checked before casting.